### PR TITLE
Tweet のCSV ファイルを開く時は明示的に、常にutf_8 を指定するよう修正

### DIFF
--- a/src/createWordCloud.py
+++ b/src/createWordCloud.py
@@ -34,7 +34,7 @@ def main():
         print("引数が不正です")
         exit()
 
-    with open(args[1], 'r') as f:
+    with open(args[1], 'r', encoding="utf_8") as f:
         reader = csv.reader(f, delimiter='\t')
         texts = []
         for row in reader:


### PR DESCRIPTION
# 対応内容
Tweet のCSV ファイルを開く時は明示的に、常にutf_8 を指定するよう修正した

# 確認方法
日本語が含まれているTweet ファイルを解析にかけて正常終了すること。

# クローズするissue
Close #8

# このタスクで発生したissue
なし

# その他
おそらく`LANG`, `LANGUAGE` が設定されていない環境でbatch を実行するとissue に示したエラーが出ることになると思います。
backend 側のissue にも上げる予定ですが、php-fpm のDocker 環境で実行すると本エラーが出るみたいです…。